### PR TITLE
Add New Validation Rule (Persian Alpha Eng Num)

### DIFF
--- a/lang/en/persian-validation.php
+++ b/lang/en/persian-validation.php
@@ -4,6 +4,7 @@ return [
 	'persian_alpha' 			    => 'The :attribute must be a persian alphabet.',
     'persian_num'				    => 'The :attribute must be a persian number.',
     'persian_alpha_num'			    => 'The :attribute must be a persian alphabet or number.',
+    'persian_alpha_eng_num'			    => 'The :attribute must be a persian alphabet or number or english number.',
     'persian_not_accept'		    => 'The :attribute could not be contain persian alphabet or number.',
     'ir_mobile'				        => 'The :attribute must be a iranian mobile number.',
     'ir_phone'				        => 'The :attribute must be a iranian phone number.',

--- a/lang/fa/persian-validation.php
+++ b/lang/fa/persian-validation.php
@@ -6,6 +6,7 @@ return [
 	'persian_alpha' 			    => ':attribute فقط میتواند شامل حروف فارسی باشد.',
 	'persian_num'				    => ':attribute فقط میتواند شامل اعداد فارسی باشد.',
 	'persian_alpha_num'			    => ':attribute فقط میتواند شامل حروف و اعداد فارسی باشد.',
+	'persian_alpha_eng_num'			    => ':attribute فقط میتواند شامل حروف و اعداد فارسی و اعداد انگلیسی باشد.',
     'persian_not_accept'			=> ':attribute فقط میتواند شامل حروف یا اعداد لاتین باشد.',
     'ir_mobile'				        => $invalidMsg,
     'ir_phone' 				        => $invalidMsg,

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,7 @@ You can access to validation rules by passing the rules key according blew follo
 | persian_alpha | Persian alphabet | صادق
 | persian_num | Persian numbers | ۱۲۳۴
 | persian_alpha_num | Persian alphabet and numbers |صادق۱۲۳۴
+| persian_alpha_eng_num | Persian alphabet and numbers with english numbers |صادق۱۲34
 | persian_not_accept | Doesn't accept Persian alphabet and numbers | cant be persian
 | ir_mobile | Iranian mobile numbers | 00989173456789, +989173456789, 989173456789, 09173456789, 91712345678
 | ir_phone | Iranian phone numbers | 37236445
@@ -72,6 +73,17 @@ Validate Persian alpha num:
 $input = [ '۰فارسی۱۲۳۴۵۶۷۸۹' ];
 
 $rules = [ 'persian_alpha_num' ];
+
+Validator::make( $input, $rules );
+```
+
+### Persian Alpha Eng Num
+Validate Persian alpha num with english num:
+
+```
+$input = [ '۰فارسی۱۲۳۴۵6789' ];
+
+$rules = [ 'persian_alpha_eng_num' ];
 
 Validator::make( $input, $rules );
 ```
@@ -151,6 +163,8 @@ Validator::make( $request->all(), [
   'age'           => 'persian_num|required',  // Validate Persian numbers and check it's required
 
   'city'          => 'persian_alpha_num|min:10',  // Validate persian alphabet & numbers at least 10 digit accepted
+
+  'address'       => 'persian_alpha_eng_num',  // Validate persian alphabet & numbers with english numbers
 
   'mobile'        => 'ir_mobile', // Validate mobile number
 

--- a/src/PersianValidationServiceProvider.php
+++ b/src/PersianValidationServiceProvider.php
@@ -18,6 +18,7 @@ class PersianValidationServiceProvider extends ServiceProvider
         'persian_alpha'         => 'PersianAlpha',
         'persian_num'           => 'PersianNumber',
         'persian_alpha_num'     => 'PersianAlphaNumber',
+        'persian_alpha_eng_num'     => 'PersianAlphaEngNumber',
         'persian_not_accept'    => 'PersianNotAccept',
         'ir_mobile'             => 'IranianMobile',
         'ir_phone'              => 'IranianPhone',

--- a/src/PersianValidators.php
+++ b/src/PersianValidators.php
@@ -129,7 +129,7 @@ class PersianValidators
      */
     public function validateIranianPostalCode($attribute, $value, $parameters)
     {
-        return preg_match("\b(?!(\d)\1{3})[13-9]{4}[1346-9]-?[013-9]{5}\b", $value);
+        return preg_match("/\b(?!(\d)\1{3})[13-9]{4}[1346-9]-?[013-9]{5}\b/", $value);
     }
 
     /**

--- a/src/PersianValidators.php
+++ b/src/PersianValidators.php
@@ -48,6 +48,20 @@ class PersianValidators
         return preg_match('/^[\x{600}-\x{6FF}\x{200c}\x{064b}\x{064d}\x{064c}\x{064e}\x{064f}\x{0650}\x{0651}\s]+$/u', $value);
     }
 
+
+    /**
+     * Validate persian alphabet, persian number, english number and space.
+     *
+     * @param $attribute
+     * @param $value
+     * @param $parameters
+     * @return bool
+     */
+    public function validatePersianAlphaEngNumber($attribute, $value, $parameters)
+    {
+        return preg_match('/^[\x{600}-\x{6FF}\x{200c}\x{064b}\x{064d}\x{064c}\x{064e}\x{064f}\x{0650}\x{0651}\0-9\s]+$/u', $value);
+    }
+
     /**
      * Validate string that is not contain persian alphabet and number.
      *

--- a/tests/PersianValidationTest.php
+++ b/tests/PersianValidationTest.php
@@ -116,6 +116,41 @@ class PersianValidationTest extends TestCase
     }
 
     /**
+     * Unit test of persian alphabet and number with english number
+     *
+     * @return void
+     */
+    public function testPersianAlphaEngNumber()
+    {
+        $this->value = "Sadegh1234";
+        $this->assertEquals(false, $this->persianValidator->validatePersianAlphaEngNumber($this->attribute, $this->value, $this->parameters));
+
+        $this->value = "1111صادق";
+        $this->assertEquals(true, $this->persianValidator->validatePersianAlphaEngNumber($this->attribute, $this->value, $this->parameters));
+
+        $this->value =  "1111صادق۱۲۳۴";
+        $this->assertEquals(true, $this->persianValidator->validatePersianAlphaEngNumber($this->attribute, $this->value, $this->parameters));
+
+        $this->value =  "صادق";
+        $this->assertEquals(true, $this->persianValidator->validatePersianAlphaEngNumber($this->attribute, $this->value, $this->parameters));
+
+        $this->value =  "۱۲۳۴";
+        $this->assertEquals(true, $this->persianValidator->validatePersianAlphaEngNumber($this->attribute, $this->value, $this->parameters));
+
+        $this->value =  "1234";
+        $this->assertEquals(true, $this->persianValidator->validatePersianAlphaEngNumber($this->attribute, $this->value, $this->parameters));
+
+        $this->value =  "Sadegh۱۲۳۴صادق";
+        $this->assertEquals(false, $this->persianValidator->validatePersianAlphaEngNumber($this->attribute, $this->value, $this->parameters));
+
+        $this->value =  "۱۲۳۴ صادق";
+        $this->assertEquals(true, $this->persianValidator->validatePersianAlphaEngNumber($this->attribute, $this->value, $this->parameters));
+
+	    $this->value = "وَحِیُدّ‌الٍمٌاًسی";
+	    $this->assertEquals(true, $this->persianValidator->validatePersianAlphaEngNumber($this->attribute, $this->value, $this->parameters));
+    }
+
+    /**
      * Unit test of iranian mobile number
      *
      * @return void


### PR DESCRIPTION
I needed a rule for my address parameter to validate if its only contain Persian letters with Persian & English Numbers, So i add `persian_alpha_eng_num` to validation rules.