### PR TITLE
Wrong publish path for lang files

### DIFF
--- a/src/PersianValidationServiceProvider.php
+++ b/src/PersianValidationServiceProvider.php
@@ -42,7 +42,8 @@ class PersianValidationServiceProvider extends ServiceProvider
     public function boot()
     {
         $vendorLangPath = $langLoaderPath = __DIR__.'/../lang/';
-        $resourceLangPath = resource_path('lang/');
+        // In Laravel 9+, lang files are in root path of app.
+        $baseLangPath = base_path('lang/');
         $langFileName = 'persian-validation';
         $langNamespace = 'sbpValidation';
 


### PR DESCRIPTION
If lang files publishes to resource path; then it damages the entire system of localization.
Because of this, laravel fallbacks to resource/lang and reads localization files from there not /lang.
And in result, laravel just shows keys instead of key's value.