### PR TITLE
fix ir_national_id rule class mapping

### DIFF
--- a/src/PersianValidationServiceProvider.php
+++ b/src/PersianValidationServiceProvider.php
@@ -29,7 +29,7 @@ class PersianValidationServiceProvider extends ServiceProvider
         'ir_postal_code'                     => 'IranianPostalCode',
         'ir_bank_card_number'                => 'IranianBankCardNumber',
         'ir_iban'                            => 'IranianBankIban',
-        'ir_national_id'                     => 'IranianNationalID',
+        'ir_national_id'                     => 'IranianNationalId',
         'ir_company_id'                      => 'IranianCompanyId',
     ];
 


### PR DESCRIPTION
In UNIX-like operating systems, class names are case-sensitive. This PR fixes the class name case for ir_national_id rule.