### PR TITLE
fix: remove wrong validation for national ID

### DIFF
--- a/src/Rules/IranianNationalId.php
+++ b/src/Rules/IranianNationalId.php
@@ -50,9 +50,7 @@ class IranianNationalId implements ValidationRule
             $value = str_pad($value, 10, '0', STR_PAD_LEFT);
         }
 
-        if (! preg_match('/^(?!(\d)\1{9}$)[0-9]{10}$/', $value) ||
-            ! $this->isValidNationalCode($value)
-        ) {
+        if (! $this->isValidNationalCode($value)) {
             $fail(Helper::translationKey('ir_national_id'))->translate();
         }
     }


### PR DESCRIPTION
Remove unnecessary validation that prevents a repeated digit from being used as a national ID

There is a [official news](https://www.fardanews.com/%D8%A8%D8%AE%D8%B4-%D9%81%D8%B1%D9%87%D9%86%DA%AF-96/127747-%D8%B1%D9%86%D8%AF%D8%AA%D8%B1%DB%8C%D9%86-%D8%B4%D9%85%D8%A7%D8%B1%D9%87-%D9%85%D9%84%DB%8C-%D8%A8%D9%84%D8%A7%DB%8C-%D8%AC%D8%A7%D9%86-%D8%B5%D8%A7%D8%AD) that says `1111111111` is a valid national ID