### PR TITLE
fix: check national id length before checking its characters

### DIFF
--- a/src/Rules/IranianNationalId.php
+++ b/src/Rules/IranianNationalId.php
@@ -4,6 +4,7 @@ namespace Sadegh19b\LaravelPersianValidation\Rules;
 
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Support\Str;
 use Sadegh19b\LaravelPersianValidation\Support\Helper;
 
 class IranianNationalId implements ValidationRule
@@ -73,6 +74,10 @@ class IranianNationalId implements ValidationRule
      */
     protected function isValidNationalCode(string $value): bool
     {
+        if (Str::length($value) !== 10) {
+            return false;
+        }
+
         $sum = 0;
         $values = str_split($value);
 

--- a/src/Rules/IranianNationalId.php
+++ b/src/Rules/IranianNationalId.php
@@ -4,7 +4,6 @@ namespace Sadegh19b\LaravelPersianValidation\Rules;
 
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Support\Str;
 use Sadegh19b\LaravelPersianValidation\Support\Helper;
 
 class IranianNationalId implements ValidationRule
@@ -74,7 +73,7 @@ class IranianNationalId implements ValidationRule
      */
     protected function isValidNationalCode(string $value): bool
     {
-        if (Str::length($value) !== 10) {
+        if (mb_strlen($value) !== 10) {
             return false;
         }
 


### PR DESCRIPTION
After removing an unnecessary RegEx validation in #29, the length of national ID is not checked and throws `Undefined array key` ErrorException if the input length is not equal to 10.

This PR adds the national ID length check back.